### PR TITLE
Do not use BUILD_SHARED_LIBS as define in the code. When this define …

### DIFF
--- a/CommonConfig.cmake
+++ b/CommonConfig.cmake
@@ -24,7 +24,7 @@ if (NOT DEFINED BUILD_SHARED_LIBS)
 endif()
 # When set to OFF, the library will be built as a static library
 if (${BUILD_SHARED_LIBS})
-    add_definitions(-DBUILD_SHARED_LIBS)
+    add_definitions(-D${PROJECT_NAME}_BUILD_SHARED_LIBS)
 endif()
 
 

--- a/config.cmake.in
+++ b/config.cmake.in
@@ -29,5 +29,5 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include_directories(@TARGET_INCLUDE_INSTALL_DIRS@)
 
 if (@BUILD_SHARED_LIBS@)
-    add_definitions(-DBUILD_SHARED_LIBS)
+    add_definitions(-D@PROJECT_NAME@_BUILD_SHARED_LIBS)
 endif()


### PR DESCRIPTION
…is used in other libraries as well, it can have a different value.

If so, it leads to wrongly defined export symbols.