### PR TITLE
Move all binaries into the same directory.

### DIFF
--- a/AddQtTest.cmake
+++ b/AddQtTest.cmake
@@ -1,10 +1,6 @@
-include(SetOutputDir)
-
 macro(add_qt_test TEST_NAME SRCS)
     find_package(Qt5Test REQUIRED)
 
-    set_global_output_dir(${CMAKE_BINARY_DIR}/tests)
-    
     add_executable(${TEST_NAME} ${SRCS})
 
     add_test(NAME ${TEST_NAME} COMMAND $<TARGET_FILE:${TEST_NAME}>)

--- a/CommonConfig.cmake
+++ b/CommonConfig.cmake
@@ -94,3 +94,7 @@ include(CodeCoverage)
 
 # Common compiler flags
 include(CompilerFlags)
+
+# Put all binaries in single directory (so libraries and executables work together in Windows)
+include(SetOutputDir)
+set_global_output_dir("${CMAKE_BINARY_DIR}/bin")


### PR DESCRIPTION
On Windows, the applications will automatically find their dependent libraries.