### PR TITLE
Fix VS2015 compiler warning when using QString library

### DIFF
--- a/CompilerFlags.cmake
+++ b/CompilerFlags.cmake
@@ -192,6 +192,9 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 #                        "/wd4512"   # suppress warning: assignment operator could not be generated
                                     # A fix is planned in Qt 5.4.2 (https://bugreports.qt.io/browse/QTBUG-7233)
                                     # Check later with Qt >= 5.4.2 if warning suppression can be removed
+                        "/wd4714"   # suppress warning: marked __forceinline but are not inlined
+                                    # Fixed in Qt 5.10.0 (https://bugreports.qt.io/browse/QTBUG-55042)
+                                    # Check later with Qt >= 5.10.0 if warning suppression can be removed
                         "/nologo"
                         "/EHsc-"    # disable exceptions
                         "/GR-"      # disable RTTI


### PR DESCRIPTION
Visual studio 2015 (rightfully) gives warning C4714 complaining
that certain Qt functions are marked __forceinline but are not inlined
This is a bug in Qt (https://bugreports.qt.io/browse/QTBUG-55042)
This is fixed in 5.10.0, but we are using 5.9, so until we switch to
Qt 5.10 disable this warning to make this compile using VS2015